### PR TITLE
Inject resizeService onto mixin

### DIFF
--- a/addon/mixins/resize-aware.js
+++ b/addon/mixins/resize-aware.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 
-const { Mixin } = Ember;
+const { Mixin, inject } = Ember;
 const { floor } = Math;
 
 export default Mixin.create({
+  resizeService: Ember.inject.service('resize-service'),
   resizeEventsEnabled: true,
   resizeDebouncedEventsEnabled: true,
 


### PR DESCRIPTION
Stubbing services in integration tests for Ember components requires services to be injected on the component. Any component extending this mixin will fail the default test unless the resizeService is injected onto it.
