### PR TITLE
Remove (apparently) unused dependencies:

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "2.4.1",
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -31,7 +30,6 @@
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.1",
     "ember-cli-sauce": "^1.4.0",
-    "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
- ember-ajax 
- ember-cli-sri

Both dependencies look out of place in an addon to help with  window.resize and I could not find any code related to them. So let’s clean up. :)