### PR TITLE
addon support

### DIFF
--- a/app/initializers/resize.js
+++ b/app/initializers/resize.js
@@ -1,11 +1,18 @@
+import Ember from 'ember';
 import ResizeService from 'ember-resize/services/resize';
 import config from '../config/environment';
+
+const { getWithDefault } = Ember;
 
 export function initialize() {
   let application = arguments[1] || arguments[0];
 
-  const { resizeServiceDefaults } = config;
-  const { injectionFactories } = resizeServiceDefaults;
+  const resizeServiceDefaults = getWithDefault(config, 'resizeServiceDefaults', {
+    widthSensitive: true,
+    heightSensitive: true,
+    debounceTimeout: 200
+  });
+  const injectionFactories = getWithDefault(resizeServiceDefaults, 'injectionFactories', ['view', 'component']) ;
 
   application.register('config:resize-service', resizeServiceDefaults, { instantiate: false });
   application.register('service:resize', ResizeService);

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,12 +1,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {
-    resizeServiceDefaults: {
-      widthSensitive: true,
-      heightSensitive: true,
-      debounceTimeout: 200,
-      injectionFactories: ['view', 'component']
-    }
-  };
+  return { };
 };


### PR DESCRIPTION
When trying to use `ember-resize` inside another addon, `resizeServiceDefaults` comes back as `undefined`. This PR fixes the issue by bringing the default configuration directly into the initializer. I'm not committed to this approach, so if you can think of a way to do this that keeps your defaults separate from the initializer, I'd be happy to implement.
