### PR TITLE
Configuration changes

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,0 +1,26 @@
+
+import Ember from 'ember';
+
+const { getWithDefault, typeOf } = Ember;
+
+const DEFAULTS = {
+  widthSensitive: true,
+  heightSensitive: true,
+  debounceTimeout: 200,
+  injectionFactories: ['view', 'component']
+};
+
+export default {
+  widthSensitive: DEFAULTS.widthSensitive,
+  heightSensitive: DEFAULTS.heightSensitive,
+  debounceTimeout: DEFAULTS.debounceTimeout,
+  injectionFactories: DEFAULTS.injectionFactories,
+
+  load(config) {
+    for (let property in this) {
+      if (this.hasOwnProperty(property) && typeOf(this[property]) !== 'function') {
+        this[property] = getWithDefault(config, property, DEFAULTS[property]);
+      }
+    }
+  }
+};

--- a/addon/services/resize.js
+++ b/addon/services/resize.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
+import configuration from 'ember-resize/configuration';
 
 // jscs:disable disallowDirectPropertyAccess
 const Base = Ember.Service || Ember.Object;
-const keys = Object.keys || Ember.keys;
 // jscs:enable disallowDirectPropertyAccess
 
-const { Evented, String: { classify }, computed: { oneWay }, run: { debounce }, getWithDefault, set } = Ember;
+const { Evented, run: { debounce }, get } = Ember;
 
 export default Base.extend(Evented, {
   _oldWidth: null,
@@ -13,13 +13,12 @@ export default Base.extend(Evented, {
   _oldWidthDebounced: null,
   _oldHeightDebounced: null,
 
-  debounceTimeout: oneWay('defaultDebounceTimeout'),
-  widthSensitive: oneWay('defaultWidthSensitive'),
-  heightSensitive: oneWay('defaultHeightSensitive'),
+  debounceTimeout: get(configuration, 'debounceTimeout'),
+  widthSensitive: get(configuration, 'widthSensitive'),
+  heightSensitive: get(configuration, 'heightSensitive'),
 
   init() {
     this._super(...arguments);
-    this._setDefaults();
     this._onResizeHandler = (evt) => {
       this._fireResizeNotification(evt);
       debounce(this, this._fireDebouncedResizeNotification, evt, this.get('debounceTimeout'));
@@ -30,16 +29,6 @@ export default Base.extend(Evented, {
   destroy() {
     this._super(...arguments);
     this._uninstallResizeListener();
-  },
-
-  _setDefaults() {
-    const defaults = getWithDefault(this, 'resizeServiceDefaults', {});
-
-    keys(defaults).map((key) => {
-      const classifiedKey = classify(key);
-      const defaultKey = `default${classifiedKey}`;
-      return set(this, defaultKey, defaults[key]);
-    });
   },
 
   _hasWindowSizeChanged(w, h, debounced=false) {

--- a/app/initializers/resize.js
+++ b/app/initializers/resize.js
@@ -1,17 +1,15 @@
 import ResizeService from 'ember-resize/services/resize';
-import config from '../config/environment';
+import configuration from 'ember-resize/configuration';
+import ENV from '../config/environment';
 
 export function initialize() {
   let application = arguments[1] || arguments[0];
 
-  const { resizeServiceDefaults } = config;
-  const { injectionFactories } = resizeServiceDefaults;
+  configuration.load(ENV['resizeServiceDefaults'] || {});
 
-  application.register('config:resize-service', resizeServiceDefaults, { instantiate: false });
   application.register('service:resize', ResizeService);
-  application.inject('service:resize', 'resizeServiceDefaults', 'config:resize-service');
 
-  injectionFactories.forEach(factory => {
+  configuration.injectionFactories.forEach(factory => {
     application.inject(factory, 'resizeService', 'service:resize');
   });
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,12 +1,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {
-    resizeServiceDefaults: {
-      widthSensitive: true,
-      heightSensitive: true,
-      debounceTimeout: 200,
-      injectionFactories: ['view', 'component']
-    }
-  };
+  return { };
 };

--- a/tests/acceptance/configuration.js
+++ b/tests/acceptance/configuration.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+import configuration from 'ember-resize/configuration';
+
+const { run } = Ember;
+
+let application;
+
+module('Acceptance | Configuration', {
+  beforeEach() {
+    application = startApp();
+  },
+
+  afterEach() {
+    run(application, 'destroy');
+  }
+});
+
+test('Ensure config values set in consuming application config are mirrored on the resize service', (assert) => {
+  // because we set the resizeServiceDefaults.debounceTimeout to 500 in the dummy app config.
+  assert.equal(configuration.debounceTimeout, 500);
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,9 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+    resizeServiceDefaults: {
+      debounceTimeout: 500
     }
   };
 

--- a/tests/unit/configuration.js
+++ b/tests/unit/configuration.js
@@ -1,0 +1,48 @@
+import configuration from 'ember-resize/configuration';
+import { module, test } from 'qunit';
+
+module('Unit | Configuration', {
+  afterEach() {
+    configuration.load({});
+  }
+});
+
+test('widthSensitive defaults to true', function(assert) {
+  configuration.load({});
+  assert.ok(configuration.widthSensitive);
+});
+
+test('heightSensitive defaults to true', function(assert) {
+  configuration.load({});
+  assert.ok(configuration.heightSensitive);
+});
+
+test('debounceTimeout defaults to 200', function(assert) {
+  configuration.load({});
+  assert.equal(configuration.debounceTimeout, 200);
+});
+
+test('injectionFactories defaults to an array of ["view", "component"]', function(assert) {
+  configuration.load({});
+  assert.equal(configuration.injectionFactories, ['view', 'component']);
+});
+
+test('configuration.load sets widthSensitive correctly', function(assert) {
+  configuration.load({ widthSensitive: false });
+  assert.ok(!configuration.widthSensitive);
+});
+
+test('configuration.load sets heightSensitive correctly', function(assert) {
+  configuration.load({ heightSensitive: false });
+  assert.ok(!configuration.heightSensitive);
+});
+
+test('configuration.load sets debounceTimeout correctly', function(assert) {
+  configuration.load({ debounceTimeout: 500 });
+  assert.equal(configuration.debounceTimeout, 500);
+});
+
+test('configuration.load sets injectionFactories correctly', function(assert) {
+  configuration.load({ injectionFactories: [] });
+  assert.equal(configuration.injectionFactories, []);
+});

--- a/tests/unit/initializers/resize-test.js
+++ b/tests/unit/initializers/resize-test.js
@@ -22,16 +22,3 @@ test('service is registered to the container', function(assert) {
   initialize(container, application);
   assert.ok(application.__container__.lookup('service:resize'), 'registered as service:resize in the container after initializer');
 });
-
-test('service configuration is registered to the container', function(assert) {
-  assert.ok(!application.__container__.lookup('config:resize-service'), 'not registered as config:resize-service in the container before initializer');
-  initialize(container, application);
-  assert.ok(application.__container__.lookup('config:resize-service'), 'registered as config:resize-service in the container after initializer');
-});
-
-test('service configuration is injected onto the resize service', function(assert) {
-  initialize(container, application);
-  let resize = application.__container__.lookup('service:resize');
-  assert.deepEqual(resize.get('resizeServiceDefaults'), application.__container__.lookup('config:resize-service'), 'defaults are registered to service as "resizeServiceDefaults"');
-});
-


### PR DESCRIPTION
I have been having issues related to #24, I basically changed how the config is handled in `ember-resize` to match how it is handled in `ember-simple-auth`. Let me know if you want anything changed. I believe this to be a more straightforward approach and more easily debuggable.

- Adds configuration singleton
- Resize service will read from configuration singleton instead of having config injected into it
- Addon initializer will merge get the config from the consuming app, then merge its set config values into the configuration singleton
- Adds test for configuration values set on consuming application config being reflected in ember-resize configuration singleton
- Adds tests for configuration singleton internal default logic
- Removes register of the the `resize-service` into the consuming app config
- Removes injection of the `config:resize-service` into the resize-service

Fixes #24, #23