### PR TITLE
chore: avoid using getWithDefault

### DIFF
--- a/addon/services/resize.ts
+++ b/addon/services/resize.ts
@@ -1,4 +1,4 @@
-import { computed, getWithDefault, set } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import Evented from '@ember/object/evented';
 import { cancel, debounce } from '@ember/runloop';
 import Service from '@ember/service';
@@ -55,7 +55,7 @@ class ResizeService extends Service.extend(Evented, {
   }
 
   public _setDefaults() {
-    const defaults = getWithDefault(this, 'resizeServiceDefaults', {} as any);
+    const defaults = (get(this, 'resizeServiceDefaults') === undefined ? {} as any : get(this, 'resizeServiceDefaults'));
 
     Object.keys(defaults).map((key: keyof ResizeDefaults) => {
       const classifiedKey = classify(key);

--- a/app/initializers/resize.ts
+++ b/app/initializers/resize.ts
@@ -1,16 +1,16 @@
 // eslint-disable-next-line no-unused-vars
 import Application from '@ember/application';
-import { getWithDefault } from '@ember/object';
+import { get } from '@ember/object';
 import ResizeService from 'ember-resize/services/resize';
 import config from '../config/environment';
 
 export function initialize(application: Pick<Application, 'register'|'inject'|'unregister'|'resolveRegistration'>) {
-  const resizeServiceDefaults = getWithDefault(config, 'resizeServiceDefaults', {
+  const resizeServiceDefaults = (get(config, 'resizeServiceDefaults') === undefined ? {
     debounceTimeout: 200,
     heightSensitive: true,
     widthSensitive: true,
-  });
-  const injectionFactories = getWithDefault(resizeServiceDefaults, 'injectionFactories', ['view', 'component']) || [];
+  } : get(config, 'resizeServiceDefaults'));
+  const injectionFactories = (get(resizeServiceDefaults, 'injectionFactories') === undefined ? ['view', 'component'] : get(resizeServiceDefaults, 'injectionFactories')) || [];
 
   application.unregister('config:resize-service');
 


### PR DESCRIPTION
This PR avoids the deprecation `getWithDefault` in Ember app > 3.21 
 - https://github.com/emberjs/rfcs/blob/master/text/0554-deprecate-getwithdefault.md
 - https://deprecations.emberjs.com/v3.x/#toc_ember-metal-get-with-default